### PR TITLE
不透明度調整メニューを追加

### DIFF
--- a/Sukeru/MainWindow.xaml
+++ b/Sukeru/MainWindow.xaml
@@ -21,6 +21,7 @@
     <Window.ContextMenu>
         <ContextMenu>
             <MenuItem x:Name="colorMenuItem" Header="Color"/>
+            <MenuItem x:Name="opacityMenuItem" Header="Opacity"/>
             <MenuItem Header="TopMost" Click="TopMostMenuItem_Click" IsCheckable="True"/>
             <MenuItem x:Name="specifySizeMenuItem" Header="Specify Size" Click="SpecifySizeMenuItemMenuItem_Click" IsChecked="True"/>
             <MenuItem Header="Exit" Click="ExitMenuItem_Click"/>

--- a/Sukeru/MainWindow.xaml.cs
+++ b/Sukeru/MainWindow.xaml.cs
@@ -123,6 +123,29 @@ namespace MifuminSoft.Sukeru
                     colorMenuItem.Items.Add(menuItem);
                 }
             }
+            if (opacityMenuItem.Items.Count == 0)
+            {
+                for (int i = 1; i <= 10; i++)
+                {
+                    var opacity = i * 10;
+                    var menuItem = new MenuItem()
+                    {
+                        Header = $"{opacity}%",
+                        Tag = opacity,
+                        IsCheckable = true,
+                        IsChecked = opacity / 100.0 == Opacity,
+                    };
+                    menuItem.Click += (s, _) =>
+                    {
+                        Opacity = (int)((MenuItem)s).Tag / 100.0;
+                        foreach (MenuItem item in opacityMenuItem.Items)
+                        {
+                            item.IsChecked = item == s;
+                        }
+                    };
+                    opacityMenuItem.Items.Add(menuItem);
+                }
+            }
         }
 
         private void Window_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
`MainWindow.xaml` に「Opacity」メニュー項目を追加し、ウィンドウの不透明度を調整できるようにしました。`MainWindow.xaml.cs` では、1から10までの値に基づいて不透明度の選択肢を動的に生成し、クリック時にウィンドウの不透明度が変更される機能を実装しました。

resolve #8